### PR TITLE
Base functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>5.0.0-beta.24</version> <!-- replace $version with the latest version -->
+            <version>5.0.0-beta.24</version>
             <exclusions>
                 <exclusion>
                     <groupId>club.minnced</groupId>
@@ -45,5 +45,39 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20211205</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.4</version>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <configuration>
+                    <minimizeJar>false</minimizeJar>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,24 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.github.smputils</groupId>
-  <artifactId>ChatConnect</artifactId>
-  <version>1.0-SNAPSHOT</version>
-  <packaging>jar</packaging>
+    <groupId>io.github.smputils</groupId>
+    <artifactId>ChatConnect</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
-  <name>ChatConnect</name>
-  <url>http://www.example.com</url>
+    <name>ChatConnect</name>
+    <url>http://www.example.com</url>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>22</maven.compiler.source>
-    <maven.compiler.target>22</maven.compiler.target>
-  </properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>22</maven.compiler.source>
+        <maven.compiler.target>22</maven.compiler.target>
+    </properties>
 
-  <repositories>
+    <repositories>
         <repository>
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
@@ -31,6 +32,18 @@
             <artifactId>spigot-api</artifactId>
             <version>1.19.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.dv8tion</groupId>
+            <artifactId>JDA</artifactId>
+            <version>5.0.0-beta.24</version> <!-- replace $version with the latest version -->
+            <exclusions>
+                <exclusion>
+                    <groupId>club.minnced</groupId>
+                    <artifactId>opus-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/io/github/smputils/chatconnect/ChatConnect.java
+++ b/src/main/java/io/github/smputils/chatconnect/ChatConnect.java
@@ -2,13 +2,19 @@ package io.github.smputils.chatconnect;
 
 import org.bukkit.plugin.java.JavaPlugin;
 
+import io.github.smputils.chatconnect.config.PluginConfig;
 import io.github.smputils.chatconnect.minecraft.ChatListener;
 
 public class ChatConnect extends JavaPlugin {
+
+    PluginConfig config;
+
     @Override
     public void onEnable() {
-        getLogger().info("Plugin Enabled!");
+        config = new PluginConfig(this);
+
         getServer().getPluginManager().registerEvents(new ChatListener(), this);
+        getLogger().info("Plugin Enabled!");
     }
 
     @Override

--- a/src/main/java/io/github/smputils/chatconnect/ChatConnect.java
+++ b/src/main/java/io/github/smputils/chatconnect/ChatConnect.java
@@ -3,22 +3,30 @@ package io.github.smputils.chatconnect;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import io.github.smputils.chatconnect.config.PluginConfig;
+import io.github.smputils.chatconnect.discord.DiscordBot;
 import io.github.smputils.chatconnect.minecraft.ChatListener;
 
 public class ChatConnect extends JavaPlugin {
 
-    PluginConfig config;
+    private PluginConfig config;
+    private DiscordBot bot;
 
     @Override
     public void onEnable() {
         config = new PluginConfig(this);
-
+        bot = new DiscordBot(config);
+        
         getServer().getPluginManager().registerEvents(new ChatListener(), this);
         getLogger().info("Plugin Enabled!");
     }
 
     @Override
     public void onDisable() {
+        try {
+            bot.shutdown();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
         getLogger().info("Plugin Disabled!");
     }
 }

--- a/src/main/java/io/github/smputils/chatconnect/ChatConnect.java
+++ b/src/main/java/io/github/smputils/chatconnect/ChatConnect.java
@@ -1,7 +1,10 @@
 package io.github.smputils.chatconnect;
 
+import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import io.github.smputils.chatconnect.common.ChatMessage;
+import io.github.smputils.chatconnect.common.mediator.MessageMediator;
 import io.github.smputils.chatconnect.config.PluginConfig;
 import io.github.smputils.chatconnect.discord.DiscordBot;
 import io.github.smputils.chatconnect.minecraft.ChatListener;
@@ -15,6 +18,13 @@ public class ChatConnect extends JavaPlugin {
     public void onEnable() {
         config = new PluginConfig(this);
         bot = new DiscordBot(config);
+
+        MessageMediator
+                .getInstance()
+                .getDiscordMessages()
+                .subscribe((ChatMessage message) -> {
+                    Bukkit.broadcastMessage("<" + message.userName() + "> " + message.message());
+                });
         
         getServer().getPluginManager().registerEvents(new ChatListener(), this);
         getLogger().info("Plugin Enabled!");

--- a/src/main/java/io/github/smputils/chatconnect/ChatConnect.java
+++ b/src/main/java/io/github/smputils/chatconnect/ChatConnect.java
@@ -2,10 +2,13 @@ package io.github.smputils.chatconnect;
 
 import org.bukkit.plugin.java.JavaPlugin;
 
+import io.github.smputils.chatconnect.minecraft.ChatListener;
+
 public class ChatConnect extends JavaPlugin {
     @Override
     public void onEnable() {
         getLogger().info("Plugin Enabled!");
+        getServer().getPluginManager().registerEvents(new ChatListener(), this);
     }
 
     @Override

--- a/src/main/java/io/github/smputils/chatconnect/common/ChatMessage.java
+++ b/src/main/java/io/github/smputils/chatconnect/common/ChatMessage.java
@@ -1,0 +1,5 @@
+package io.github.smputils.chatconnect.common;
+
+public record ChatMessage(String userName, String message) {
+    
+}

--- a/src/main/java/io/github/smputils/chatconnect/common/mediator/MessageMediator.java
+++ b/src/main/java/io/github/smputils/chatconnect/common/mediator/MessageMediator.java
@@ -1,0 +1,32 @@
+package io.github.smputils.chatconnect.common.mediator;
+
+import io.github.smputils.chatconnect.common.ChatMessage;
+import io.github.smputils.chatconnect.common.observer.Publisher;
+
+// Mediator where all messages pass through and are processed
+public class MessageMediator {
+    
+    // Singleton
+    private static MessageMediator instance = new MessageMediator();
+
+    private MessageMediator() {}
+
+    public static MessageMediator getInstance() {
+        return instance;
+    }
+
+    // Publisher of messages originating from Discord
+    private Publisher<ChatMessage> discordMessages = new Publisher<>();
+    
+    // Publisher of messages originating from Minecraft
+    private Publisher<ChatMessage> minecraftMessages = new Publisher<>();
+
+    public Publisher<ChatMessage> getDiscordMessages() {
+        return discordMessages;
+    }
+
+    public Publisher<ChatMessage> getMinecraftMessages() {
+        return minecraftMessages;
+    }
+
+}

--- a/src/main/java/io/github/smputils/chatconnect/common/observer/Publisher.java
+++ b/src/main/java/io/github/smputils/chatconnect/common/observer/Publisher.java
@@ -1,0 +1,20 @@
+package io.github.smputils.chatconnect.common.observer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Publisher<T> {
+    
+    private List<Subscriber<T>> subscribers = new ArrayList<>();
+
+    public void publish(T t) {
+        for (var subscriber : subscribers) {
+            subscriber.update(t);
+        }
+    }
+
+    public void subscribe(Subscriber<T> subscriber) {
+        subscribers.add(subscriber);
+    }
+
+}

--- a/src/main/java/io/github/smputils/chatconnect/common/observer/Subscriber.java
+++ b/src/main/java/io/github/smputils/chatconnect/common/observer/Subscriber.java
@@ -1,0 +1,8 @@
+package io.github.smputils.chatconnect.common.observer;
+
+@FunctionalInterface
+public interface Subscriber<T> {
+    
+    public void update(T t);
+
+}

--- a/src/main/java/io/github/smputils/chatconnect/config/PluginConfig.java
+++ b/src/main/java/io/github/smputils/chatconnect/config/PluginConfig.java
@@ -1,0 +1,41 @@
+package io.github.smputils.chatconnect.config;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class PluginConfig {
+
+    private JavaPlugin plugin;
+    private FileConfiguration config;
+
+    public PluginConfig(JavaPlugin plugin) {
+        this.plugin = plugin;
+
+        config = plugin.getConfig();
+
+        config.addDefault("bot.token", "");
+        config.addDefault("bot.guild_id", "");
+        config.addDefault("bot.channel_id", "");
+
+        config.options().copyDefaults(true);
+
+        saveConfig();
+    }
+
+    private void saveConfig() {
+        plugin.saveConfig();
+    }
+
+    public String getDiscordToken() {
+        return config.getString("bot.token");
+    }
+
+    public String getDiscordGuildId() {
+        return config.getString("bot.guild_id");
+    }
+
+    public String getDiscordChannelId() {
+        return config.getString("bot.channel_id");
+    }
+
+}

--- a/src/main/java/io/github/smputils/chatconnect/config/PluginConfig.java
+++ b/src/main/java/io/github/smputils/chatconnect/config/PluginConfig.java
@@ -14,7 +14,6 @@ public class PluginConfig {
         config = plugin.getConfig();
 
         config.addDefault("bot.token", "");
-        config.addDefault("bot.guild_id", "");
         config.addDefault("bot.channel_id", "");
 
         config.options().copyDefaults(true);
@@ -28,10 +27,6 @@ public class PluginConfig {
 
     public String getDiscordToken() {
         return config.getString("bot.token");
-    }
-
-    public String getDiscordGuildId() {
-        return config.getString("bot.guild_id");
     }
 
     public String getDiscordChannelId() {

--- a/src/main/java/io/github/smputils/chatconnect/discord/DiscordBot.java
+++ b/src/main/java/io/github/smputils/chatconnect/discord/DiscordBot.java
@@ -1,0 +1,50 @@
+package io.github.smputils.chatconnect.discord;
+
+import java.time.Duration;
+
+import io.github.smputils.chatconnect.common.ChatMessage;
+import io.github.smputils.chatconnect.common.mediator.MessageMediator;
+import io.github.smputils.chatconnect.config.PluginConfig;
+import io.github.smputils.chatconnect.discord.listeners.MessageListener;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.requests.GatewayIntent;
+
+public class DiscordBot {
+
+    private JDA jda;
+
+    public DiscordBot(PluginConfig config) {
+        jda = JDABuilder
+                .createLight(config.getDiscordToken(), GatewayIntent.GUILD_MESSAGES, GatewayIntent.MESSAGE_CONTENT)
+                .addEventListeners(new MessageListener())
+                .build();
+
+        MessageMediator
+                .getInstance()
+                .getMinecraftMessages()
+                .subscribe((ChatMessage message) -> {
+                    jda.getTextChannelById(config.getDiscordChannelId())
+                            .sendMessage("<" + message.userName() + "> " + message.message())
+                            .submit();
+                });
+
+        try {
+            jda.awaitReady();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+    }
+
+    public void shutdown() throws InterruptedException {
+        // Initial shutdown, allowing for some RestActions to still go through
+        jda.shutdown();
+        // Wait up to 10 seconds for requests to finish
+        if (!jda.awaitShutdown(Duration.ofSeconds(10))) {
+            jda.shutdownNow(); // Cancel request queue
+            jda.awaitShutdown(); // Wait until shutdown is complete (indefinitely)
+        }
+    }
+
+}

--- a/src/main/java/io/github/smputils/chatconnect/discord/DiscordBot.java
+++ b/src/main/java/io/github/smputils/chatconnect/discord/DiscordBot.java
@@ -16,9 +16,15 @@ public class DiscordBot {
 
     public DiscordBot(PluginConfig config) {
         jda = JDABuilder
-                .createLight(config.getDiscordToken(), GatewayIntent.GUILD_MESSAGES, GatewayIntent.MESSAGE_CONTENT)
-                .addEventListeners(new MessageListener())
+                .createLight(config.getDiscordToken(), GatewayIntent.GUILD_MESSAGES, GatewayIntent.MESSAGE_CONTENT, GatewayIntent.GUILD_MEMBERS)
+                .addEventListeners(new MessageListener(config))
                 .build();
+
+        try {
+            jda.awaitReady();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
 
         MessageMediator
                 .getInstance()
@@ -28,12 +34,6 @@ public class DiscordBot {
                             .sendMessage("<" + message.userName() + "> " + message.message())
                             .submit();
                 });
-
-        try {
-            jda.awaitReady();
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
 
     }
 

--- a/src/main/java/io/github/smputils/chatconnect/discord/listeners/MessageListener.java
+++ b/src/main/java/io/github/smputils/chatconnect/discord/listeners/MessageListener.java
@@ -1,13 +1,30 @@
 package io.github.smputils.chatconnect.discord.listeners;
 
+import io.github.smputils.chatconnect.common.ChatMessage;
+import io.github.smputils.chatconnect.common.mediator.MessageMediator;
+import io.github.smputils.chatconnect.config.PluginConfig;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
 public class MessageListener extends ListenerAdapter {
 
+    PluginConfig config;
+
+    public MessageListener(PluginConfig config) {
+        this.config = config;
+    }
+
     @Override
     public void onMessageReceived(MessageReceivedEvent event) {
-        // TODO: implement
+        Message message = event.getMessage();
+        Member member = event.getGuild().retrieveMemberById(event.getAuthor().getId()).complete();
+
+        if (!member.getUser().isBot() && message.getChannelId().equals(config.getDiscordChannelId())) {
+            MessageMediator.getInstance().getDiscordMessages()
+                    .publish(new ChatMessage(member.getEffectiveName(), message.getContentRaw()));
+        }
     }
 
 }

--- a/src/main/java/io/github/smputils/chatconnect/discord/listeners/MessageListener.java
+++ b/src/main/java/io/github/smputils/chatconnect/discord/listeners/MessageListener.java
@@ -1,0 +1,13 @@
+package io.github.smputils.chatconnect.discord.listeners;
+
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+
+public class MessageListener extends ListenerAdapter {
+
+    @Override
+    public void onMessageReceived(MessageReceivedEvent event) {
+        // TODO: implement
+    }
+
+}

--- a/src/main/java/io/github/smputils/chatconnect/minecraft/ChatListener.java
+++ b/src/main/java/io/github/smputils/chatconnect/minecraft/ChatListener.java
@@ -1,0 +1,13 @@
+package io.github.smputils.chatconnect.minecraft;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+
+public class ChatListener implements Listener {
+
+    @EventHandler
+    public void onChatMessage(AsyncPlayerChatEvent e) {
+    }
+
+}

--- a/src/main/java/io/github/smputils/chatconnect/minecraft/ChatListener.java
+++ b/src/main/java/io/github/smputils/chatconnect/minecraft/ChatListener.java
@@ -4,10 +4,16 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 
+import io.github.smputils.chatconnect.common.ChatMessage;
+import io.github.smputils.chatconnect.common.mediator.MessageMediator;
+
 public class ChatListener implements Listener {
 
     @EventHandler
     public void onChatMessage(AsyncPlayerChatEvent e) {
+        MessageMediator.getInstance()
+                .getMinecraftMessages()
+                .publish(new ChatMessage(e.getPlayer().getDisplayName(), e.getMessage()));
     }
 
 }


### PR DESCRIPTION
Implements basic functionality that passes messages from discord (via a bot) to minecraft (via a spigot plugin), and vice versa.
Currently, it contains a discord bot client that gets launched when the plugin is loaded. Needs the user to input the bot account token and the target channel id in the plugin config.